### PR TITLE
Refactor: replace buffer with Uint8Array

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,9 +106,9 @@ export class SilentPayment {
 
   static taggedHash(tag: "BIP0352/Inputs" | "BIP0352/SharedSecret", data: Uint8Array): Uint8Array {
     const hash = crypto.createHash("sha256");
-    const tagHash = hash.update(tag, "utf-8").digest();
+    const tagHash = new Uint8Array(hash.update(tag, "utf-8").digest());
     const ss = concatUint8Arrays([tagHash, tagHash, data]);
-    return crypto.createHash("sha256").update(ss).digest();
+    return new Uint8Array(crypto.createHash("sha256").update(ss).digest());
   }
 
   static _outpointsHash(parameters: UTXO[], A: Uint8Array): Uint8Array {
@@ -321,7 +321,7 @@ export class SilentPayment {
    * takes BIP-39 mnemonic seed and returns shareable static payment code; also: Bscan, bscan, Bspend, bspend
    */
   static seedToCode(bip39seed: string, accountNum = 0, passphrase = ''): { address: string; Bscan: Uint8Array; bscan: Uint8Array; Bspend: Uint8Array, bspend: Uint8Array } {
-    const root = bip32.fromSeed(bip39.mnemonicToSeedSync(bip39seed, passphrase));
+    const root = bip32.fromSeed(new Uint8Array(bip39.mnemonicToSeedSync(bip39seed, passphrase)));
     const scanXprv = root.derivePath(`m/352'/0'/${accountNum}'/1'/0`);
     const spendXprv = root.derivePath(`m/352'/0'/${accountNum}'/0'/0`);
     const Bscan = scanXprv.publicKey;
@@ -330,7 +330,7 @@ export class SilentPayment {
     const bspend = spendXprv.privateKey;
 
     const bech32Version = 0;
-    const words = [bech32Version].concat(bech32m.toWords(Buffer.concat([Bscan, Bspend])));
+    const words = [bech32Version].concat(bech32m.toWords(concatUint8Arrays([Bscan, Bspend])));
     const address = bech32m.encode('sp', words, 1023);
     return { address, Bscan, bscan, Bspend, bspend };
   }

--- a/src/noble_ecc.ts
+++ b/src/noble_ecc.ts
@@ -16,11 +16,11 @@ import * as necc from "@noble/secp256k1";
 necc.utils.sha256Sync = (...messages: Uint8Array[]): Uint8Array => {
   const sha256 = createHash("sha256");
   for (const message of messages) sha256.update(message);
-  return sha256.digest();
+  return new Uint8Array(sha256.digest());
 };
 
 necc.utils.hmacSha256Sync = (key: Uint8Array, ...messages: Uint8Array[]): Uint8Array => {
-  const hash = createHmac("sha256", Buffer.from(key));
+  const hash = createHmac("sha256", key);
   messages.forEach((m) => hash.update(m));
   return Uint8Array.from(hash.digest());
 };
@@ -98,7 +98,7 @@ const ecc = {
     return necc.signSync(h, d, { der: false, extraEntropy: e });
   },
 
-  signSchnorr: (h: Uint8Array, d: Uint8Array, e: Uint8Array = Buffer.alloc(32, 0x00)): Uint8Array => {
+  signSchnorr: (h: Uint8Array, d: Uint8Array, e: Uint8Array = new Uint8Array(32).fill(0x00)): Uint8Array => {
     return necc.schnorr.signSync(h, d, e);
   },
 


### PR DESCRIPTION
Replaced several instances of `Buffer` with `Uint8Array`.

Some instances were not replaced because  `Buffer.readUInt32LE` https://nodejs.org/api/buffer.html#bufreaduint32leoffset is not available on `Uint8Array`.

**Note:** A follow-up PR could implement a `readUInt32LE` equivalent for `Uint8Array` to fully replace `Buffer`.
