### PR TITLE
Treat intermediate identity as identity in pubkey/privkey sums

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -199,11 +199,21 @@ export class SilentPayment {
       throw new Error("No eligible UTXOs with private keys found");
     }
 
-    // summary of every item in array
-    const ret = keys.reduce((acc, key) => {
-      return new Uint8Array(ecc.privateAdd(acc, key) as Uint8Array);
-    });
+    // Sum scalars left-to-right. tiny-secp256k1 privateAdd returns null for the
+    // zero scalar (identity), which is a valid intermediate when keys cancel.
+    let ret: Uint8Array | null = keys[0];
+    for (let i = 1; i < keys.length; i++) {
+      if (ret === null) {
+        ret = keys[i];
+        continue;
+      }
+      const sum = ecc.privateAdd(ret, keys[i]);
+      ret = sum === null ? null : new Uint8Array(sum);
+    }
 
+    if (ret === null) {
+      throw new Error("Sum of private keys is zero");
+    }
     return ret;
   }
 
@@ -301,13 +311,28 @@ export class SilentPayment {
     if (pubkeys.length === 0) return null;
 
     let result = pubkeys[0];
+    let atIdentity = false;
     for (let i = 1; i < pubkeys.length; i++) {
+      if (atIdentity) {
+        result = pubkeys[i];
+        atIdentity = false;
+        continue;
+      }
       const sum = ecc.pointAdd(result, pubkeys[i], compressed);
-      if (!sum) return null;
+      if (!sum) {
+        // Valid opposite points sum to infinity. Keep going; only the final
+        // sum being identity is a failure. Invalid points still fail.
+        if (ecc.isPoint(result) && ecc.isPoint(pubkeys[i])) {
+          atIdentity = true;
+          continue;
+        }
+        return null;
+      }
       result = sum;
     }
 
-    if (result.length === 32) {
+    if (atIdentity) return null;
+    if (result!.length === 32) {
       // We have an x-only point, need to determine correct parity
       // Use the pointCompress function to get the proper compressed format
       try {

--- a/tests/silent-payment.test.ts
+++ b/tests/silent-payment.test.ts
@@ -491,3 +491,21 @@ it("can detect incoming payment in tx output (having output script only)  using 
 
   console.log("1000 tweak mults took", (end - start) / 1000, "sec");
 });
+
+it("sumPubKeys is order-independent when an intermediate sum is the point at infinity", () => {
+  // Reporter scalars from BlueWallet/SilentPayments#30 (A + (-A) = 0 mod n).
+  const a = hexToUint8Array("a6df6a0bb448992a301df4258e06a89fe7cf7146f59ac3bd5ff26083acb22ceb");
+  const minusA = hexToUint8Array("592095f44bb766d5cfe20bda71f9575ed2df6b9fb9addc7e5fdffe0923841456");
+  const Apub = ecc.pointFromScalar(a, true);
+  const minusApub = ecc.pointFromScalar(minusA, true);
+  assert.ok(Apub);
+  assert.ok(minusApub);
+
+  const cancelFirst = SilentPayment.sumPubKeys([Apub, minusApub, Apub]);
+  const cancelLast = SilentPayment.sumPubKeys([Apub, Apub, minusApub]);
+
+  expect(cancelFirst).not.toBeNull();
+  expect(cancelLast).not.toBeNull();
+  assert.deepStrictEqual(cancelFirst, cancelLast);
+  assert.deepStrictEqual(cancelFirst, Apub);
+});


### PR DESCRIPTION
Treat intermediate identity as identity in pubkey and privkey sums.
Reported by @shuv-amp.
Fixes #30

sumPubKeys and _sumPrivkeys aborted as soon as an intermediate sum was the ECC identity.
Continue through intermediate identity; only fail if the final sum is identity.

## Test plan
- New unit test for both key orders using reporter scalars
- Existing BIP-352 sending vectors stay green
